### PR TITLE
複数要素間でdisableWeek等の設定が共有される不具合を修正

### DIFF
--- a/data/themes/THEME-NAME/js/module/form/datapicker-opt.js
+++ b/data/themes/THEME-NAME/js/module/form/datapicker-opt.js
@@ -1,15 +1,9 @@
 /*
-  UPDATE 2022.10.11
-  ver 1.0
+  UPDATE 2026.07.03
+  ver 1.1
   holiday: 2022年以降対応(過去分非対応)
 */
 (function ($) {
-  var settings = {};
-  var css = {};
-  var annual = {};
-  var onetime = {};
-  var holidays = {};
-  var prepared = {};
 
   $.fn.holiday = function (method) {
     if (methods[method]) {
@@ -21,7 +15,7 @@
     }
   };
 
-  var methods = {
+  const methods = {
     //初期処理
     init: function (options) {
       //datepicker ロードチェック
@@ -29,131 +23,142 @@
         return this;
       }
 
-      //オプション設定
-      settings = $.extend(true, {}, {
-        disableHoliday: {
-          // 毎年決まった休み（祝日：振替あり[substitute]）
-          '01': [{ 'day': '01', 'name': '元日', 'substitute': 'false' }, { 'day': '02', 'name': '三が日', 'substitute': 'flase' }, { 'day': '03', 'name': '三が日', 'substitute': 'flase' }, { 'day': '2/1', 'name': '成人の日' }],
-          '02': [{ 'day': '11', 'name': '建国記念日' }, { 'day': '23', 'name': '天皇誕生日' }],
-          '03': [{ 'day': 'spring equinox', 'name': '春分の日' }],
-          '04': [{ 'day': '29', 'name': '昭和の日' }],
-          '05': [{ 'day': '03', 'name': '憲法記念日' }, { 'day': '04', 'name': 'みどりの日' }, { 'day': '05', 'name': 'こどもの日' }],
-          '07': [{ 'day': '3/1', 'name': '海の日', 'not': '2020' }],
-          '08': [{ 'day': '11', 'name': '山の日' }],
-          '09': [{ 'day': '3/1', 'name': '敬老の日' }, { 'day': 'autumnal equinox', 'name': '秋分の日' }],
-          '10': [{ 'day': '2/1', 'name': 'スポーツの日' }],
-          '11': [{ 'day': '03', 'name': '文化の日' }, { 'day': '23', 'name': '勤労感謝の日' }],
-          '12': []
-        },
-        disableWeek: [
-          // 毎週決まった休み（日曜始まり）
-          [null],
-          [null],
-          [null],
-          [null],
-          [null],
-          [null],
-          [null]
-        ],
-        disableDates: {
-          // 年によって変わるもの（振替なし）
-          '201509': [{ 'day': '22', 'name': '国民の休日' }],
-          '202609': [{ 'day': '22', 'name': '国民の休日' }],
-          '203209': [{ 'day': '21', 'name': '国民の休日' }],
-          '203709': [{ 'day': '22', 'name': '国民の休日' }]
-        },
-        //曜日、祝祭日のCSSスタイルクラス（曜日や日付で色をつけたい場合）
-        'css': [
-          { 'day': 0, 'class': 'day-sunday' },
-          { 'day': 1, 'class': 'day-monday' },
-          { 'day': 2, 'class': 'day-tuesday' },
-          { 'day': 3, 'class': 'day-wednesday' },
-          { 'day': 4, 'class': 'day-thursday' },
-          { 'day': 5, 'class': 'day-friday' },
-          { 'day': 6, 'class': 'day-saturday' },
-          { 'day': 'holiday', 'class': 'day-holiday' } //休み登録日
-        ]
-      }, options);
-
-      //スタイルの登録
-      $.each(settings.css, function (key, val) {
-        if (typeof val['class'] != "undefined") {
-          css[val['day']] = val['class'];
-        }
-      });
-
-      // 毎年定期的な休みの調整
-      // デフォルト
-      annual = settings.disableHoliday;
-      // 追加分
-      $.each(settings.addAnnualHoliday, function (key, val) {
-        inputFormatMD(val);
-        if (annual[m]) {
-          annual[m].push({ 'day': d, 'substitute': 'false' });
-        } else {
-          annual[m] = [{ 'day': d, 'substitute': 'false' }];
-        }
-      });
-      // 削除分
-      $.each(settings.removeAnnualHoliday, function (key, val) {
-        inputFormatMD(val);
-        if (annual[m]) {
-          for (var i = 0; i < annual[m].length; i++) {
-            if (annual[m][i]['day'] == d) {
-              annual[m].splice(i, 1);
-              i--;
-            }
-          }
-        }
-      });
-      // 単発休み
-      // デフォルト
-      onetime = settings.disableDates;
-      // 追加分
-      $.each(settings.addOntimeHoliday, function (key, val) {
-        inputFormatYMD(val);
-        if (onetime[y + m]) {
-          onetime[y + m].push({ 'day': d, 'substitute': 'false' });
-        } else {
-          onetime[y + m] = [{ 'day': d, 'substitute': 'false' }];
-        }
-      });
-      // 削除分はbeforeShowDay内
-
       return this.each(function () {
-        if (typeof $(this).datepicker != "function") {
-          return true;
+        const $this = $(this);
+
+        if (typeof $this.datepicker != "function") {
+          return true; // continue
         }
         //初期化済みチェック
-        if ($(this).data("holiday")) {
-          return true;
+        if ($this.data("holiday")) {
+          return true; // continue
         }
-        //初期化データ設定
-        $(this).data("holiday", {
-          init: true
+
+        //オプション設定（要素ごとに独立したオブジェクトとして生成）
+        const settings = $.extend(true, {}, {
+          disableHoliday: {
+            // 毎年決まった休み（祝日：振替あり[substitute]）
+            '01': [{ 'day': '01', 'name': '元日', 'substitute': 'false' }, { 'day': '02', 'name': '三が日', 'substitute': 'flase' }, { 'day': '03', 'name': '三が日', 'substitute': 'flase' }, { 'day': '2/1', 'name': '成人の日' }],
+            '02': [{ 'day': '11', 'name': '建国記念日' }, { 'day': '23', 'name': '天皇誕生日' }],
+            '03': [{ 'day': 'spring equinox', 'name': '春分の日' }],
+            '04': [{ 'day': '29', 'name': '昭和の日' }],
+            '05': [{ 'day': '03', 'name': '憲法記念日' }, { 'day': '04', 'name': 'みどりの日' }, { 'day': '05', 'name': 'こどもの日' }],
+            '07': [{ 'day': '3/1', 'name': '海の日', 'not': '2020' }],
+            '08': [{ 'day': '11', 'name': '山の日' }],
+            '09': [{ 'day': '3/1', 'name': '敬老の日' }, { 'day': 'autumnal equinox', 'name': '秋分の日' }],
+            '10': [{ 'day': '2/1', 'name': 'スポーツの日' }],
+            '11': [{ 'day': '03', 'name': '文化の日' }, { 'day': '23', 'name': '勤労感謝の日' }],
+            '12': []
+          },
+          disableWeek: [
+            // 毎週決まった休み（日曜始まり）
+            [null],
+            [null],
+            [null],
+            [null],
+            [null],
+            [null],
+            [null]
+          ],
+          disableDates: {
+            // 年によって変わるもの（振替なし）
+            '201509': [{ 'day': '22', 'name': '国民の休日' }],
+            '202609': [{ 'day': '22', 'name': '国民の休日' }],
+            '203209': [{ 'day': '21', 'name': '国民の休日' }],
+            '203709': [{ 'day': '22', 'name': '国民の休日' }]
+          },
+          //曜日、祝祭日のCSSスタイルクラス（曜日や日付で色をつけたい場合）
+          'css': [
+            { 'day': 0, 'class': 'day-sunday' },
+            { 'day': 1, 'class': 'day-monday' },
+            { 'day': 2, 'class': 'day-tuesday' },
+            { 'day': 3, 'class': 'day-wednesday' },
+            { 'day': 4, 'class': 'day-thursday' },
+            { 'day': 5, 'class': 'day-friday' },
+            { 'day': 6, 'class': 'day-saturday' },
+            { 'day': 'holiday', 'class': 'day-holiday' } //休み登録日
+          ]
+        }, options);
+
+        //スタイルの登録
+        const css = {};
+        $.each(settings.css, function (key, val) {
+          if (typeof val['class'] != "undefined") {
+            css[val['day']] = val['class'];
+          }
         });
 
+        // 毎年定期的な休みの調整
+        // デフォルト
+        const annual = settings.disableHoliday;
+        // 追加分
+        $.each(settings.addAnnualHoliday, function (key, val) {
+          const md = inputFormatMD(val);
+          if (annual[md.m]) {
+            annual[md.m].push({ 'day': md.d, 'substitute': 'false' });
+          } else {
+            annual[md.m] = [{ 'day': md.d, 'substitute': 'false' }];
+          }
+        });
+        // 削除分
+        $.each(settings.removeAnnualHoliday, function (key, val) {
+          const md = inputFormatMD(val);
+          if (annual[md.m]) {
+            for (let i = 0; i < annual[md.m].length; i++) {
+              if (annual[md.m][i]['day'] == md.d) {
+                annual[md.m].splice(i, 1);
+                i--;
+              }
+            }
+          }
+        });
+        // 単発休み
+        // デフォルト
+        const onetime = settings.disableDates;
+        // 追加分
+        $.each(settings.addOntimeHoliday, function (key, val) {
+          const ymd = inputFormatYMD(val);
+          if (onetime[ymd.y + ymd.m]) {
+            onetime[ymd.y + ymd.m].push({ 'day': ymd.d, 'substitute': 'false' });
+          } else {
+            onetime[ymd.y + ymd.m] = [{ 'day': ymd.d, 'substitute': 'false' }];
+          }
+        });
+        // 削除分はbeforeShowDay内（prepare内）
+
+        //この要素専用の状態オブジェクト
+        const instance = {
+          settings: settings,
+          css: css,
+          annual: annual,
+          onetime: onetime,
+          holidays: {},
+          prepared: {}
+        };
+
+        //初期化データ設定（要素ごとに保持）
+        $this.data("holiday", instance);
+
         //祝祭日と日付スタイルの設定（表示する分の日をループでそれぞれの条件に合うのかチェック）
-        $(this).datepicker("option", "beforeShowDay", function (day) {
-          var $self = $.fn.holiday;
-          var attr = $self("attr", day); //90行目:その日の情報取得
-          var dow = day.getDay();
-          var title = "";
+        $this.datepicker("option", "beforeShowDay", function (day) {
+          const attr = getAttr(instance, day); //その日の情報取得
+          const dow = day.getDay();
+          let title = "";
           if (typeof attr['name'] != "undefined") {
             title = attr['name'];
           }
-          var style = "";
-          var counted_day = countWeek(day);
+          let style = "";
+          const counted_day = countWeek(day);
           //-1を指定した曜日は全部選べない様に
           if (typeof attr['class'] != "undefined") {
             style = attr['class']; //.day-holiday
             return [false, style, title];
-          } else if (settings.disableWeek[counted_day.day][0] == -1) {
+          } else if (instance.settings.disableWeek[counted_day.day][0] == -1) {
             return [false, 'ui-state-disabled'];
-          } else if (settings.disableWeek[counted_day.day].indexOf(counted_day.count) != -1) {
+          } else if (instance.settings.disableWeek[counted_day.day].indexOf(counted_day.count) != -1) {
             return [false, 'ui-state-disabled'];
-          } else if (typeof css[dow] != "undefined") {
-            style = css[dow]; //.day-***day
+          } else if (typeof instance.css[dow] != "undefined") {
+            style = instance.css[dow]; //.day-***day
           }
           return [true, style, title];
         });
@@ -169,95 +174,99 @@
         }
         //祝祭日と日付スタイルの除去
         $(this).datepicker("option", "beforeShowDay", null);
+        $(this).removeData("holiday");
       });
     },
 
-    //祝祭日の属性の取得
+    //祝祭日の属性の取得（外部から $(el).holiday('attr', day) として呼ぶ用）
     attr: function (day) {
-      //日付が文字の場合はDate型に変換する。
-      if (typeof day == "string") {
-        var match = day.match(/^(20\d{2})(\d{2})(\d{2})$/);
-        if (match) {
-          match.shift();
-          day = new Date(match.join("/"));
-        } else {
-          day = new Date(day);
-        }
-      }
-      //祝祭日の計算
-      var Y = day.getFullYear();
-      var M = padzero(day.getMonth() + 1);
-      var D = padzero(day.getDate());
-      //161行目:prepare:その月の休みリストを取得しているかどうか（その日だけでなく、丸ごと取得する）
-      if (typeof prepared[Y + M] == "undefined") {
-        prepare(Y, M);
-      }
-      //祝祭日のチェック
-      var YMD = Y + M + D;
-      if (typeof holidays[YMD] != "undefined") {
-        return holidays[YMD];
-      } else {
+      const instance = $(this).data("holiday");
+      if (!instance) {
         return {};
       }
+      return getAttr(instance, day);
+    }
+  };
+
+  //祝祭日の属性取得（内部共通処理）：要素ごとの instance を明示的に受け取る
+  const getAttr = function (instance, day) {
+    //日付が文字の場合はDate型に変換する。
+    if (typeof day == "string") {
+      const match = day.match(/^(20\d{2})(\d{2})(\d{2})$/);
+      if (match) {
+        match.shift();
+        day = new Date(match.join("/"));
+      } else {
+        day = new Date(day);
+      }
+    }
+    //祝祭日の計算
+    const Y = day.getFullYear();
+    const M = padzero(day.getMonth() + 1);
+    const D = padzero(day.getDate());
+    //prepare:その月の休みリストを取得しているかどうか（その日だけでなく、丸ごと取得する）
+    if (typeof instance.prepared[Y + M] == "undefined") {
+      prepare(instance, Y, M);
+    }
+    //祝祭日のチェック
+    const YMD = Y + M + D;
+    if (typeof instance.holidays[YMD] != "undefined") {
+      return instance.holidays[YMD];
+    } else {
+      return {};
     }
   };
 
   //祝祭日計算
-  var prepare = function (Y, M) {
+  const prepare = function (instance, Y, M) {
     //作成済みチェック
-    if (typeof prepared[Y + M] != "undefined") {
+    if (typeof instance.prepared[Y + M] != "undefined") {
       return true;
     }
 
     //年間の祝祭日の計算
-    var attr, substitutes = {};
-    var d, dayyear;
+    const substitutes = {};
     //祝祭日をリストに設定
-    if (typeof annual[M] != "undefined") {
-      $.each(annual[M], function (key, val) {
-        holidaysList(Y, M, d, val, substitutes);
+    if (typeof instance.annual[M] != "undefined") {
+      $.each(instance.annual[M], function (key, val) {
+        holidaysList(instance, Y, M, val, substitutes);
       });
     }
 
     // 個別の祝祭日の追加
     // デフォルト
-    if (typeof onetime[Y + M] != "undefined") {
-      $.each(onetime[Y + M], function (key, val) {
-        holidaysList(Y, M, d, val, substitutes);
+    if (typeof instance.onetime[Y + M] != "undefined") {
+      $.each(instance.onetime[Y + M], function (key, val) {
+        holidaysList(instance, Y, M, val, substitutes);
       });
     };
 
-    $.each(settings.removeOntimeHoliday, function (key, val) {
-      d = inputFormatYMD(val);
-      // console.log(holidays, y + m + d)
-      if (holidays[y + m + d]) {
-        $.each(holidays, function (key, val) {
-          console.log(key)
-          if (key == y + m + d) {
-            delete holidays[key];
-            console.log(holidays)
-          }
-        })
+    $.each(instance.settings.removeOntimeHoliday, function (key, val) {
+      const ymd = inputFormatYMD(val);
+      const key2 = ymd.y + ymd.m + ymd.d;
+      if (instance.holidays[key2]) {
+        delete instance.holidays[key2];
       }
     });
 
     //振替休日の補正（祝日が続く場合）
     $.each(substitutes, function (key, val) {
-      key = new Date(key);
-      d = key.getFullYear() + padzero(key.getMonth() + 1) + padzero(key.getDate());
-      while (typeof holidays[d] != "undefined") {
-        key.setDate(key.getDate() + 1);
-        d = key.getFullYear() + padzero(key.getMonth() + 1) + padzero(key.getDate());
+      const dt = new Date(key);
+      let d = dt.getFullYear() + padzero(dt.getMonth() + 1) + padzero(dt.getDate());
+      while (typeof instance.holidays[d] != "undefined") {
+        dt.setDate(dt.getDate() + 1);
+        d = dt.getFullYear() + padzero(dt.getMonth() + 1) + padzero(dt.getDate());
       }
-      holidays[d] = val;
+      instance.holidays[d] = val;
     });
 
-    prepared[Y + M] = true;
+    instance.prepared[Y + M] = true;
     return true;
   }
 
-  var holidaysList = function (Y, M, d, val, substitutes) {
-    d = null;
+  const holidaysList = function (instance, Y, M, val, substitutes) {
+    let d = null;
+    let dayyear;
     // not最優先
     if (val['not']) {
       if (parseInt(val['not']) == Y) {
@@ -312,12 +321,12 @@
       return true; //continue;
     }
 
-    attr = {};
+    const attr = {};
     attr['name'] = val['name'];
     if (typeof val['class'] != "undefined") {
       attr['class'] = val['class'];
-    } else if (typeof css['holiday'] != "undefined") {
-      attr['class'] = css['holiday'];
+    } else if (typeof instance.css['holiday'] != "undefined") {
+      attr['class'] = instance.css['holiday'];
     } else {
       attr['class'] = "";
     }
@@ -327,14 +336,14 @@
       attr['substitute'] = 'true';
     }
 
-    holidays[Y + M + d] = attr;
+    instance.holidays[Y + M + d] = attr;
 
     //振替休日のチェック
-    if (holidays[Y + M + d]['substitute'] == 'true') {
-      d = new Date(Y, M - 1, d);
-      if (d.getDay() == 0) {
-        d = padzero(d.getDate() + 1);
-        substitutes[Y + "/" + M + "/" + d] = {
+    if (instance.holidays[Y + M + d]['substitute'] == 'true') {
+      const dt = new Date(Y, M - 1, d);
+      if (dt.getDay() == 0) {
+        const d2 = padzero(dt.getDate() + 1);
+        substitutes[Y + "/" + M + "/" + d2] = {
           'name': words['substitute'] + "(" + val['name'] + ")",
           'class': attr['class']
         };
@@ -343,15 +352,15 @@
   }
 
   //ゼロサプレス
-  var padzero = function (val) {
+  const padzero = function (val) {
     return ('0' + val).slice(-2);
   }
 
   //月の第ｎ番目のｍ曜日
-  var nthday = function (y, m, val) {
-    var dayOfWeek = val.split('/');
-    var firstDay = new Date(y, m - 1, 1);
-    var adjust = dayOfWeek[1] - firstDay.getDay();
+  const nthday = function (y, m, val) {
+    const dayOfWeek = val.split('/');
+    const firstDay = new Date(y, m - 1, 1);
+    let adjust = dayOfWeek[1] - firstDay.getDay();
     if (adjust < 0)
       adjust += 7;
     //第ｎ番目のｍ曜日
@@ -359,14 +368,16 @@
   }
 
   // 第ｎ週目
-  var countWeek = function (day) {
+  const countWeek = function (day) {
     return {
       day: day.getDay(),
       count: Math.floor((day.getDate() - 1) / 7) + 1
     };
   }
 
-  var inputFormatMD = function (val) {
+  //月日フォーマットの解析
+  const inputFormatMD = function (val) {
+    let m, d;
     if (val.length > 5) {
       if (val.slice(0, 2).match(/\//)) {
         m = padzero(val.slice(0, 1));
@@ -387,11 +398,13 @@
         d = val.slice(-2);
       }
     }
-    return;
+    return { m: m, d: d };
   }
 
-  var inputFormatYMD = function (val) {
-    y = val.slice(0, 4);
+  //年月日フォーマットの解析
+  const inputFormatYMD = function (val) {
+    const y = val.slice(0, 4);
+    let m, d;
     if (val.slice(6, 7).match(/\//)) {
       m = padzero(val.slice(5, 6));
     } else {
@@ -402,11 +415,11 @@
     } else {
       d = val.slice(-2);
     }
-    return d;
+    return { y: y, m: m, d: d };
   }
 
   //言語対応
-  var words = {
+  const words = {
     'substitute': '振替休日'
   };
 })(jQuery);


### PR DESCRIPTION
Before:
settings/annual/onetime/holidays/prepared/cssがIIFEのモジュール スコープ（init外側）に定義されていたため、.holiday()を複数要素に
異なるオプションで呼び出すと、後勝ちで全要素に同じ設定が適用されて
いた（例: disableWeek02が全input要素に反映される）。

After:
要素ごとにinstanceオブジェクト（settings/css/annual/onetime/
holidays/prepared）を生成し、$(el).data('holiday', instance)で 保持。beforeShowDayのクロージャもその要素専用instanceを参照する
よう修正し、要素間の独立性を担保。

あわせて以下も対応:
- inputFormatMD/inputFormatYMD内の暗黙グローバル変数(m/d/y)を除去
- var → const/let